### PR TITLE
Fix CI for Rocket diesel async example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
   test:
@@ -63,15 +64,20 @@ jobs:
             brew install mysql-client libpq sqlite coreutils
             echo "/usr/local/opt/mysql-client/bin" >> "$GITHUB_PATH"
 
+      - name: Export GitHub Actions cache environment variables (Windows, vcpkg)
+        if: matrix.platform.name == 'Windows'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
       # vcpkg --triplet x64-windows install libmysql libpq sqlite3 openssl
       # + vcpkg/installed/vcpkg (in particular, the status file)
       - name: Install Native Dependencies (Windows)
         if: matrix.platform.name == 'Windows'
         run: |
-          curl -fsS -o vcpkg.7z https://rocket.rs/static/vcpkg-2019-07-05.7z
-          7z x vcpkg.7z -y -bb0
-          xcopy .\vcpkg $env:VCPKG_INSTALLATION_ROOT /s /e /h /y /q
-          vcpkg integrate install
+          vcpkg --triplet x64-windows install libmysql libpq sqlite3 openssl
           echo "VCPKGRS_DYNAMIC=1" >> "$env:GITHUB_ENV"
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" >> "$env:GITHUB_ENV"
           echo "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\lib" >> "$env:GITHUB_PATH"
@@ -81,6 +87,39 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libmysqlclient-dev libpq-dev libsqlite3-dev
+
+      - name: Start Postgres (macOS)
+        if: matrix.platform.name == 'macOS'
+        run: |
+          brew services start postgresql@14
+          RETRIES=5
+          until pg_isready > /dev/null 2>&1 || [[ $RETRIES -eq 0 ]]; do
+            echo "waiting for Postgres to start, $((RETRIES--)) remaining attempts"
+            sleep 1
+          done
+          psql postgres -c "CREATE ROLE rocket_runner PASSWORD 'password' SUPERUSER CREATEDB INHERIT LOGIN"
+          createdb -O rocket_runner epic_todo_database
+
+      - name: Start Postgres (Linux)
+        if: matrix.platform.name == 'Linux'
+        run: |
+          sudo systemctl start postgresql.service
+          RETRIES=5
+          until pg_isready > /dev/null 2>&1 || [[ $RETRIES -eq 0 ]]; do
+            echo "waiting for Postgres to start, $((RETRIES--)) remaining attempts"
+            sleep 1
+          done
+          sudo -u postgres psql -U postgres -c "CREATE ROLE rocket_runner PASSWORD 'password' SUPERUSER CREATEDB INHERIT LOGIN"
+          sudo -u postgres createdb -O rocket_runner epic_todo_database
+
+      - name: Start Postgres (Windows)
+        if: matrix.platform.name == 'Windows'
+        run: |
+          $pgService = Get-Service -Name postgresql*
+          Set-Service -InputObject $pgService -Status running -StartupType automatic
+          Start-Process -FilePath "$env:PGBIN\pg_isready" -Wait -PassThru
+          & $env:PGBIN\psql --command "CREATE ROLE rocket_runner PASSWORD 'password' SUPERUSER CREATEDB INHERIT LOGIN"
+          & $env:PGBIN\createdb -O rocket_runner epic_todo_database
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master

--- a/examples/todo/Rocket.toml
+++ b/examples/todo/Rocket.toml
@@ -2,6 +2,6 @@
 template_dir = "static"
 
 [default.databases.epic_todo_database]
-url = "postgresql://postgres@localhost:5432/epic_todo_database"
+url = "postgresql://rocket_runner:password@localhost:5432/epic_todo_database"
 max_connections = 1
 connect_timeout = 5

--- a/examples/todo/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/examples/todo/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/examples/todo/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/examples/todo/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/examples/todo/migrations/20160720150332_create_tasks_table/up.sql
+++ b/examples/todo/migrations/20160720150332_create_tasks_table/up.sql
@@ -1,8 +1,8 @@
 CREATE TABLE tasks (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    id SERIAL PRIMARY KEY,
     description VARCHAR NOT NULL,
-    completed BOOLEAN NOT NULL DEFAULT 0
+    completed BOOLEAN NOT NULL DEFAULT FALSE
 );
 
-INSERT INTO tasks (description) VALUES ("demo task");
-INSERT INTO tasks (description) VALUES ("demo task2");
+INSERT INTO tasks (description) VALUES ('demo task');
+INSERT INTO tasks (description) VALUES ('demo task2');

--- a/examples/todo/src/tests.rs
+++ b/examples/todo/src/tests.rs
@@ -16,13 +16,13 @@ macro_rules! run_test {
         let _lock = DB_LOCK.lock();
 
         rocket::async_test(async move {
-            let rocket = super::rocket();
+            let $client = Client::tracked(super::rocket()).await.expect("Rocket client");
+            let rocket = $client.rocket();
             let mut $conn = super::Db::fetch(&rocket)
                 .expect("database")
                 .get()
                 .await
                 .expect("database connection");
-            let $client = Client::tracked(rocket).await.expect("Rocket client");
             Task::delete_all(&mut $conn).await.expect("failed to delete all tasks for testing");
 
             $block


### PR DESCRIPTION
This PR is for the upstream PR for enabling Postgres for diesel-async. There are several changes that this PR introduces to the CI configuration to ensure this works:
- Start the Postgres services on Linux, macOS, and Windows (pre-installed in GHA images, just needs to be started)
- Create the specified user and database for the example
- Swap `vcpkg` caching from a static zip to GHA `actions/cache` (this can be reverted to a static zip, but it doesn't work to download the zip, upgrade `libpq`, and roll forward; we need to re-vendor the zip cache)